### PR TITLE
feat: add investment leaderboard endpoints

### DIFF
--- a/src/contract/investments/index.ts
+++ b/src/contract/investments/index.ts
@@ -1,16 +1,17 @@
-import { and, asc, count, desc, eq } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, sql } from "drizzle-orm";
 import { z } from "zod";
 import {
 	investmentAssetsSchema,
 	investmentAssetsTable,
 	investmentPortfoliosSchema,
 	investmentPortfoliosTable,
-	investmentPriceCacheTable,
 	investmentTransactionsSchema,
 	investmentTransactionsTable,
 	type InsertDbInvestmentPortfolio,
 	type InsertDbInvestmentTransaction,
+	userSchema,
 	userStatsTable,
+	usersTable,
 } from "../../db/schema.ts";
 import { InvestmentSyncService } from "../../services/investment-sync.ts";
 import { base } from "../shared/os.ts";
@@ -748,5 +749,229 @@ export const syncPrices = base
 			assetsUpdated: 0, // Will be logged to console when complete
 			apiCallsUsed: 0,
 			durationMs: 0,
+		};
+	});
+
+/**
+ * Investment leaderboard schema for output
+ */
+const investmentLeaderboardEntrySchema = z.object({
+	user: userSchema.pick({ id: true, discordId: true, guildedId: true, username: true }),
+	rank: z.number(),
+	totalInvested: z.number(),
+	currentValue: z.number(),
+	totalProfit: z.number(),
+	profitPercent: z.number(),
+	realizedGains: z.number(),
+	unrealizedGains: z.number(),
+});
+
+/**
+ * Investment leaderboard endpoint
+ * GET /users/investments/leaderboard
+ * Returns top investors ranked by selected metric
+ */
+export const investmentLeaderboard = base
+	.input(
+		z.object({
+			metric: z.enum(["totalValue", "totalProfit", "profitPercent"]).default("totalProfit"),
+			limit: z.number().int().min(1).max(100).default(10),
+		}),
+	)
+	.output(z.array(investmentLeaderboardEntrySchema))
+	.handler(async ({ input, context }) => {
+		const { metric, limit } = input;
+
+		// Get all users with portfolios and calculate their metrics
+		// We need to aggregate portfolio data and join with latest prices
+
+		// First, get all portfolios with their assets
+		const portfolios = await context.db
+			.select({
+				userId: investmentPortfoliosTable.userId,
+				assetId: investmentPortfoliosTable.assetId,
+				quantity: investmentPortfoliosTable.quantity,
+				totalInvested: investmentPortfoliosTable.totalInvested,
+				realizedGains: investmentPortfoliosTable.realizedGains,
+				averageBuyPrice: investmentPortfoliosTable.averageBuyPrice,
+			})
+			.from(investmentPortfoliosTable)
+			.where(gt(investmentPortfoliosTable.quantity, 0));
+
+		if (portfolios.length === 0) {
+			return [];
+		}
+
+		// Get latest prices for all assets
+		const assetIds = [...new Set(portfolios.map(p => p.assetId))];
+		const priceMap = new Map<number, number>();
+
+		for (const assetId of assetIds) {
+			const priceData = await getLatestPrice(context, assetId);
+			if (priceData) {
+				priceMap.set(assetId, priceData.price);
+			}
+		}
+
+		// Aggregate by user
+		const userMetrics = new Map<number, {
+			totalInvested: number;
+			currentValue: number;
+			realizedGains: number;
+			unrealizedGains: number;
+		}>();
+
+		for (const portfolio of portfolios) {
+			const currentPrice = priceMap.get(portfolio.assetId) || portfolio.averageBuyPrice;
+			const currentValue = Math.floor((portfolio.quantity * currentPrice) / 100000);
+			const unrealizedGain = currentValue - portfolio.totalInvested;
+
+			const existing = userMetrics.get(portfolio.userId) || {
+				totalInvested: 0,
+				currentValue: 0,
+				realizedGains: 0,
+				unrealizedGains: 0,
+			};
+
+			userMetrics.set(portfolio.userId, {
+				totalInvested: existing.totalInvested + portfolio.totalInvested,
+				currentValue: existing.currentValue + currentValue,
+				realizedGains: existing.realizedGains + portfolio.realizedGains,
+				unrealizedGains: existing.unrealizedGains + unrealizedGain,
+			});
+		}
+
+		// Convert to array with calculated metrics
+		const userIds = [...userMetrics.keys()];
+		const users = await context.db
+			.select({
+				id: usersTable.id,
+				discordId: usersTable.discordId,
+				guildedId: usersTable.guildedId,
+				username: usersTable.username,
+			})
+			.from(usersTable)
+			.where(sql`${usersTable.id} IN (${sql.join(userIds.map(id => sql`${id}`), sql`, `)})`);
+
+		const userMap = new Map(users.map(u => [u.id, u]));
+
+		// Build leaderboard entries
+		const entries = [...userMetrics.entries()].map(([userId, metrics]) => {
+			const user = userMap.get(userId);
+			if (!user) return null;
+
+			const totalProfit = metrics.realizedGains + metrics.unrealizedGains;
+			const profitPercent = metrics.totalInvested > 0
+				? (totalProfit / metrics.totalInvested) * 100
+				: 0;
+
+			return {
+				user,
+				totalInvested: metrics.totalInvested,
+				currentValue: metrics.currentValue,
+				totalProfit,
+				profitPercent: Math.round(profitPercent * 100) / 100, // Round to 2 decimal places
+				realizedGains: metrics.realizedGains,
+				unrealizedGains: metrics.unrealizedGains,
+			};
+		}).filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+		// Sort by selected metric
+		const sortedEntries = entries.sort((a, b) => {
+			switch (metric) {
+				case "totalValue":
+					return b.currentValue - a.currentValue;
+				case "totalProfit":
+					return b.totalProfit - a.totalProfit;
+				case "profitPercent":
+					return b.profitPercent - a.profitPercent;
+				default:
+					return b.totalProfit - a.totalProfit;
+			}
+		});
+
+		// Add ranks and limit
+		return sortedEntries.slice(0, limit).map((entry, index) => ({
+			...entry,
+			rank: index + 1,
+		}));
+	});
+
+/**
+ * Get user's investment summary
+ * GET /users/{userId}/investments/summary
+ * Returns aggregated investment stats for a single user
+ */
+export const getInvestmentSummary = base
+	.input(
+		z.object({
+			userId: z.number(),
+		}),
+	)
+	.output(
+		z.object({
+			totalInvested: z.number(),
+			currentValue: z.number(),
+			totalProfit: z.number(),
+			profitPercent: z.number(),
+			realizedGains: z.number(),
+			unrealizedGains: z.number(),
+			holdingsCount: z.number(),
+		}),
+	)
+	.handler(async ({ input, context }) => {
+		// Get user's portfolios
+		const portfolios = await context.db
+			.select()
+			.from(investmentPortfoliosTable)
+			.where(eq(investmentPortfoliosTable.userId, input.userId));
+
+		if (portfolios.length === 0) {
+			return {
+				totalInvested: 0,
+				currentValue: 0,
+				totalProfit: 0,
+				profitPercent: 0,
+				realizedGains: 0,
+				unrealizedGains: 0,
+				holdingsCount: 0,
+			};
+		}
+
+		let totalInvested = 0;
+		let currentValue = 0;
+		let realizedGains = 0;
+		let unrealizedGains = 0;
+		let holdingsCount = 0;
+
+		for (const portfolio of portfolios) {
+			if (portfolio.quantity > 0) {
+				holdingsCount++;
+			}
+
+			const priceData = await getLatestPrice(context, portfolio.assetId);
+			const currentPrice = priceData?.price || portfolio.averageBuyPrice;
+			const portfolioValue = Math.floor((portfolio.quantity * currentPrice) / 100000);
+			const unrealizedGain = portfolioValue - portfolio.totalInvested;
+
+			totalInvested += portfolio.totalInvested;
+			currentValue += portfolioValue;
+			realizedGains += portfolio.realizedGains;
+			unrealizedGains += unrealizedGain;
+		}
+
+		const totalProfit = realizedGains + unrealizedGains;
+		const profitPercent = totalInvested > 0
+			? Math.round((totalProfit / totalInvested) * 10000) / 100
+			: 0;
+
+		return {
+			totalInvested,
+			currentValue,
+			totalProfit,
+			profitPercent,
+			realizedGains,
+			unrealizedGains,
+			holdingsCount,
 		};
 	});

--- a/src/contract/investments/investments.spec.ts
+++ b/src/contract/investments/investments.spec.ts
@@ -974,8 +974,11 @@ describe("Investments", async () => {
 				isActive: true,
 			}).returning();
 
+			if (!asset) throw new Error("Failed to create asset");
+			const assetId = asset.id;
+
 			// Initial price $100
-			await updatePrice(testDb, asset.id, 10000);
+			await updatePrice(testDb, assetId, 10000);
 
 			console.log("\n========================================");
 			console.log("20-TRANSACTION VOLATILE TEST");
@@ -1013,7 +1016,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 2: BUY 3000 coins @ $75 (crash)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 7500);
+			await updatePrice(testDb, assetId, 7500);
 
 			const buy2 = await call(buyAsset, {
 				userId: user.id,
@@ -1039,7 +1042,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 3: SELL 25% @ $50 (flash crash, panic sell)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 5000);
+			await updatePrice(testDb, assetId, 5000);
 
 			const sell3 = await call(sellAsset, {
 				userId: user.id,
@@ -1067,7 +1070,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 4: BUY 8000 coins @ $40 (bottom, buy heavily)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 4000);
+			await updatePrice(testDb, assetId, 4000);
 
 			const buy4 = await call(buyAsset, {
 				userId: user.id,
@@ -1093,7 +1096,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 5: BUY 2000 coins @ $60 (recovery)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 6000);
+			await updatePrice(testDb, assetId, 6000);
 
 			const buy5 = await call(buyAsset, {
 				userId: user.id,
@@ -1119,7 +1122,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 6: SELL 30% @ $120 (spike, take profits)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 12000);
+			await updatePrice(testDb, assetId, 12000);
 
 			const sell6 = await call(sellAsset, {
 				userId: user.id,
@@ -1147,7 +1150,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 7: BUY 4000 coins @ $95 (pullback)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 9500);
+			await updatePrice(testDb, assetId, 9500);
 
 			const buy7 = await call(buyAsset, {
 				userId: user.id,
@@ -1173,7 +1176,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 8: SELL 10% @ $150 (moon, trim position)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 15000);
+			await updatePrice(testDb, assetId, 15000);
 
 			const sell8 = await call(sellAsset, {
 				userId: user.id,
@@ -1201,7 +1204,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 9: BUY 6000 coins @ $110 (drop, accumulate)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 11000);
+			await updatePrice(testDb, assetId, 11000);
 
 			const buy9 = await call(buyAsset, {
 				userId: user.id,
@@ -1227,7 +1230,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 10: SELL 50% @ $80 (crash, sell half)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 8000);
+			await updatePrice(testDb, assetId, 8000);
 
 			const sell10 = await call(sellAsset, {
 				userId: user.id,
@@ -1255,7 +1258,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 11: BUY 10000 coins @ $65 (continue down, DCA)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 6500);
+			await updatePrice(testDb, assetId, 6500);
 
 			const buy11 = await call(buyAsset, {
 				userId: user.id,
@@ -1281,7 +1284,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 12: BUY 5000 coins @ $55 (further down, DCA)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 5500);
+			await updatePrice(testDb, assetId, 5500);
 
 			const buy12 = await call(buyAsset, {
 				userId: user.id,
@@ -1307,7 +1310,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 13: SELL 20% @ $70 (small bounce, trim)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 7000);
+			await updatePrice(testDb, assetId, 7000);
 
 			const sell13 = await call(sellAsset, {
 				userId: user.id,
@@ -1335,7 +1338,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 14: BUY 3000 coins @ $45 (new low)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 4500);
+			await updatePrice(testDb, assetId, 4500);
 
 			const buy14 = await call(buyAsset, {
 				userId: user.id,
@@ -1361,7 +1364,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 15: SELL 15% @ $90 (recovery, take some)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 9000);
+			await updatePrice(testDb, assetId, 9000);
 
 			const sell15 = await call(sellAsset, {
 				userId: user.id,
@@ -1389,7 +1392,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 16: BUY 7000 coins @ $85 (dip, add)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 8500);
+			await updatePrice(testDb, assetId, 8500);
 
 			const buy16 = await call(buyAsset, {
 				userId: user.id,
@@ -1415,7 +1418,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 17: SELL 40% @ $140 (rally, big trim)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 14000);
+			await updatePrice(testDb, assetId, 14000);
 
 			const sell17 = await call(sellAsset, {
 				userId: user.id,
@@ -1443,7 +1446,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 18: BUY 2000 coins @ $125 (pullback, small add)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 12500);
+			await updatePrice(testDb, assetId, 12500);
 
 			const buy18 = await call(buyAsset, {
 				userId: user.id,
@@ -1469,7 +1472,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 19: SELL 25% @ $180 (ATH, take profits)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 18000);
+			await updatePrice(testDb, assetId, 18000);
 
 			const sell19 = await call(sellAsset, {
 				userId: user.id,
@@ -1497,7 +1500,7 @@ describe("Investments", async () => {
 			// ============================================================
 			// TRANSACTION 20: SELL 100% @ $160 (exit all)
 			// ============================================================
-			await updatePrice(testDb, asset.id, 16000);
+			await updatePrice(testDb, assetId, 16000);
 
 			const sell20 = await call(sellAsset, {
 				userId: user.id,

--- a/src/contract/investments/investments.spec.ts
+++ b/src/contract/investments/investments.spec.ts
@@ -1,0 +1,618 @@
+import { describe, expect, it } from "bun:test";
+import { ORPCError } from "@orpc/client";
+import { call } from "@orpc/server";
+import {
+	investmentAssetsTable,
+	investmentPortfoliosTable,
+	investmentPriceCacheTable,
+	type InsertDbInvestmentAsset,
+	type InsertDbInvestmentPortfolio,
+	type InsertDbInvestmentPriceCache,
+} from "../../db/schema.ts";
+import { createTestContext, createTestDatabase } from "../shared/test-utils.ts";
+import { createUser } from "../users";
+import { getInvestmentSummary, investmentLeaderboard } from "./index.ts";
+import { userStatsWithInvestments } from "../stats";
+
+const db = await createTestDatabase();
+
+describe("Investments", async () => {
+	describe("investmentLeaderboard", () => {
+		it("should return empty array when no portfolios exist", async () => {
+			const emptyDb = await createTestDatabase();
+			const result = await call(
+				investmentLeaderboard,
+				{ metric: "totalProfit", limit: 10 },
+				createTestContext(emptyDb),
+			);
+
+			expect(result).toBeInstanceOf(Array);
+			expect(result.length).toBe(0);
+		});
+
+		it("should return users sorted by totalProfit (default metric)", async () => {
+			// Create test users
+			const user1 = await call(createUser, { username: "investor1" }, createTestContext(db));
+			const user2 = await call(createUser, { username: "investor2" }, createTestContext(db));
+			const user3 = await call(createUser, { username: "investor3" }, createTestContext(db));
+
+			// Create test asset
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "AAPL",
+				name: "Apple Inc.",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "AAPL",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Create price cache
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 15000, // $150.00
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// Create portfolios with different profit levels
+			// User1: invested 1000, current value 1500, realized 100 -> totalProfit = 600
+			const portfolio1: InsertDbInvestmentPortfolio = {
+				userId: user1.id,
+				assetId: asset.id,
+				quantity: 10000, // 10 shares
+				averageBuyPrice: 10000, // $100
+				totalInvested: 1000,
+				realizedGains: 100,
+			};
+
+			// User2: invested 2000, current value 3000, realized 200 -> totalProfit = 1200
+			const portfolio2: InsertDbInvestmentPortfolio = {
+				userId: user2.id,
+				assetId: asset.id,
+				quantity: 20000, // 20 shares
+				averageBuyPrice: 10000, // $100
+				totalInvested: 2000,
+				realizedGains: 200,
+			};
+
+			// User3: invested 1500, current value 1200, realized -100 -> totalProfit = -400
+			const portfolio3: InsertDbInvestmentPortfolio = {
+				userId: user3.id,
+				assetId: asset.id,
+				quantity: 8000, // 8 shares
+				averageBuyPrice: 18750, // $187.50
+				totalInvested: 1500,
+				realizedGains: -100,
+			};
+
+			await db.insert(investmentPortfoliosTable).values([portfolio1, portfolio2, portfolio3]);
+
+			const result = await call(investmentLeaderboard, {}, createTestContext(db));
+
+			expect(result.length).toBeGreaterThanOrEqual(3);
+			// Find our test users in results
+			const investor2 = result.find(r => r.user.username === "investor2");
+			const investor1 = result.find(r => r.user.username === "investor1");
+			const investor3 = result.find(r => r.user.username === "investor3");
+
+			expect(investor2).toBeDefined();
+			expect(investor1).toBeDefined();
+			expect(investor3).toBeDefined();
+
+			// investor2 should have highest profit
+			expect(investor2!.totalProfit).toBeGreaterThan(investor1!.totalProfit);
+			expect(investor1!.totalProfit).toBeGreaterThan(investor3!.totalProfit);
+		});
+
+		it("should return users sorted by totalValue metric", async () => {
+			// Create test users
+			const user1 = await call(createUser, { username: "valueInvestor1" }, createTestContext(db));
+			const user2 = await call(createUser, { username: "valueInvestor2" }, createTestContext(db));
+
+			// Create asset
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "MSFT",
+				name: "Microsoft",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "MSFT",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Create price cache
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 30000, // $300.00
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// User1: 10 shares @ $300 = 3000 currentValue
+			const portfolio1: InsertDbInvestmentPortfolio = {
+				userId: user1.id,
+				assetId: asset.id,
+				quantity: 10000,
+				averageBuyPrice: 20000,
+				totalInvested: 2000,
+				realizedGains: 0,
+			};
+
+			// User2: 20 shares @ $300 = 6000 currentValue
+			const portfolio2: InsertDbInvestmentPortfolio = {
+				userId: user2.id,
+				assetId: asset.id,
+				quantity: 20000,
+				averageBuyPrice: 25000,
+				totalInvested: 5000,
+				realizedGains: 0,
+			};
+
+			await db.insert(investmentPortfoliosTable).values([portfolio1, portfolio2]);
+
+			const result = await call(
+				investmentLeaderboard,
+				{ metric: "totalValue", limit: 10 },
+				createTestContext(db),
+			);
+
+			// Find our test users
+			const valueInvestor1 = result.find(r => r.user.username === "valueInvestor1");
+			const valueInvestor2 = result.find(r => r.user.username === "valueInvestor2");
+
+			expect(valueInvestor1).toBeDefined();
+			expect(valueInvestor2).toBeDefined();
+			expect(valueInvestor2!.currentValue).toBe(6000);
+			expect(valueInvestor1!.currentValue).toBe(3000);
+			expect(valueInvestor2!.rank).toBeLessThan(valueInvestor1!.rank);
+		});
+
+		it("should return users sorted by profitPercent metric", async () => {
+			// Create test users
+			const user1 = await call(createUser, { username: "percentInvestor1" }, createTestContext(db));
+			const user2 = await call(createUser, { username: "percentInvestor2" }, createTestContext(db));
+
+			// Create asset
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "TSLA",
+				name: "Tesla",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "TSLA",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Create price cache
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 20000, // $200.00
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// User1: invested 1000, current ~1500 + realized 100 = ~60% profit
+			const portfolio1: InsertDbInvestmentPortfolio = {
+				userId: user1.id,
+				assetId: asset.id,
+				quantity: 7500,
+				averageBuyPrice: 13333,
+				totalInvested: 1000,
+				realizedGains: 100,
+			};
+
+			// User2: invested 2000, current ~3000 + realized 200 = ~60% profit
+			const portfolio2: InsertDbInvestmentPortfolio = {
+				userId: user2.id,
+				assetId: asset.id,
+				quantity: 15000,
+				averageBuyPrice: 13333,
+				totalInvested: 2000,
+				realizedGains: 200,
+			};
+
+			await db.insert(investmentPortfoliosTable).values([portfolio1, portfolio2]);
+
+			const result = await call(
+				investmentLeaderboard,
+				{ metric: "profitPercent", limit: 10 },
+				createTestContext(db),
+			);
+
+			const percentInvestor1 = result.find(r => r.user.username === "percentInvestor1");
+			const percentInvestor2 = result.find(r => r.user.username === "percentInvestor2");
+
+			expect(percentInvestor1).toBeDefined();
+			expect(percentInvestor2).toBeDefined();
+			// Both should have similar profit percent
+			expect(Math.abs(percentInvestor1!.profitPercent - percentInvestor2!.profitPercent)).toBeLessThan(5);
+		});
+
+		it("should respect limit parameter", async () => {
+			const result = await call(
+				investmentLeaderboard,
+				{ metric: "totalProfit", limit: 3 },
+				createTestContext(db),
+			);
+
+			expect(result.length).toBeLessThanOrEqual(3);
+			// Verify ranks are sequential
+			for (let i = 0; i < result.length; i++) {
+				expect(result[i]?.rank).toBe(i + 1);
+			}
+		});
+
+		it("should handle division by zero for profitPercent (0 totalInvested)", async () => {
+			const user = await call(createUser, { username: "zeroInvestor" }, createTestContext(db));
+
+			// Create asset
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "BTC",
+				name: "Bitcoin",
+				assetType: "crypto",
+				apiSource: "twelvedata",
+				apiSymbol: "BTC",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Create price cache
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 5000000,
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// Portfolio with 0 totalInvested (edge case) but some quantity
+			const portfolio: InsertDbInvestmentPortfolio = {
+				userId: user.id,
+				assetId: asset.id,
+				quantity: 1000,
+				averageBuyPrice: 5000000,
+				totalInvested: 0,
+				realizedGains: 0,
+			};
+
+			await db.insert(investmentPortfoliosTable).values(portfolio);
+
+			const result = await call(
+				investmentLeaderboard,
+				{ metric: "profitPercent", limit: 100 },
+				createTestContext(db),
+			);
+
+			// User should appear with 0% profit (no division by zero error)
+			const zeroInvestor = result.find(r => r.user.username === "zeroInvestor");
+			expect(zeroInvestor).toBeDefined();
+			expect(zeroInvestor!.profitPercent).toBe(0);
+		});
+
+		it("should return proper rank numbers", async () => {
+			const result = await call(
+				investmentLeaderboard,
+				{ metric: "totalProfit", limit: 10 },
+				createTestContext(db),
+			);
+
+			// Verify ranks are sequential starting from 1
+			for (let i = 0; i < result.length; i++) {
+				expect(result[i]?.rank).toBe(i + 1);
+			}
+		});
+	});
+
+	describe("getInvestmentSummary", () => {
+		it("should return zeros for user with no investments", async () => {
+			const user = await call(createUser, { username: "noInvestmentUser" }, createTestContext(db));
+
+			const result = await call(getInvestmentSummary, { userId: user.id }, createTestContext(db));
+
+			expect(result).toEqual({
+				totalInvested: 0,
+				currentValue: 0,
+				totalProfit: 0,
+				profitPercent: 0,
+				realizedGains: 0,
+				unrealizedGains: 0,
+				holdingsCount: 0,
+			});
+		});
+
+		it("should return correct totals for user with investments", async () => {
+			const user = await call(createUser, { username: "summaryUser" }, createTestContext(db));
+
+			// Create asset
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "NFLX",
+				name: "Netflix",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "NFLX",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Create price cache: current price $400
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 40000,
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// Portfolio: 10 shares @ avg $300, current $400
+			// totalInvested: 3000
+			// currentValue: 4000
+			// unrealizedGains: 1000
+			// realizedGains: 250
+			// totalProfit: 1250
+			// profitPercent: 41.67%
+			const portfolio: InsertDbInvestmentPortfolio = {
+				userId: user.id,
+				assetId: asset.id,
+				quantity: 10000,
+				averageBuyPrice: 30000,
+				totalInvested: 3000,
+				realizedGains: 250,
+			};
+
+			await db.insert(investmentPortfoliosTable).values(portfolio);
+
+			const result = await call(getInvestmentSummary, { userId: user.id }, createTestContext(db));
+
+			expect(result.totalInvested).toBe(3000);
+			expect(result.currentValue).toBe(4000);
+			expect(result.unrealizedGains).toBe(1000);
+			expect(result.realizedGains).toBe(250);
+			expect(result.totalProfit).toBe(1250);
+			expect(result.profitPercent).toBeCloseTo(41.67, 1);
+			expect(result.holdingsCount).toBe(1);
+		});
+
+		it("should handle multiple holdings correctly", async () => {
+			const user = await call(createUser, { username: "multiHoldingUser" }, createTestContext(db));
+
+			// Create two assets
+			const asset1Data: InsertDbInvestmentAsset = {
+				symbol: "FB",
+				name: "Meta",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "FB",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset1] = await db.insert(investmentAssetsTable).values(asset1Data).returning();
+
+			const asset2Data: InsertDbInvestmentAsset = {
+				symbol: "NVDA",
+				name: "Nvidia",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "NVDA",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset2] = await db.insert(investmentAssetsTable).values(asset2Data).returning();
+
+			if (!asset1 || !asset2) throw new Error("Failed to create assets");
+
+			// Create price caches
+			await db.insert(investmentPriceCacheTable).values([
+				{ assetId: asset1.id, price: 30000, priceTimestamp: new Date() },
+				{ assetId: asset2.id, price: 50000, priceTimestamp: new Date() },
+			]);
+
+			// Create portfolios
+			const portfolios = [
+				{
+					userId: user.id,
+					assetId: asset1.id,
+					quantity: 10000, // 10 shares @ $300 = 3000
+					averageBuyPrice: 25000,
+					totalInvested: 2500,
+					realizedGains: 100,
+				},
+				{
+					userId: user.id,
+					assetId: asset2.id,
+					quantity: 5000, // 5 shares @ $500 = 2500
+					averageBuyPrice: 40000,
+					totalInvested: 2000,
+					realizedGains: 50,
+				},
+			];
+
+			await db.insert(investmentPortfoliosTable).values(portfolios);
+
+			const result = await call(getInvestmentSummary, { userId: user.id }, createTestContext(db));
+
+			expect(result.totalInvested).toBe(4500);
+			expect(result.currentValue).toBe(5500);
+			expect(result.realizedGains).toBe(150);
+			expect(result.unrealizedGains).toBe(1000);
+			expect(result.totalProfit).toBe(1150);
+			expect(result.holdingsCount).toBe(2);
+		});
+
+		it("should include realizedGains in totalProfit", async () => {
+			const user = await call(createUser, { username: "realizedGainsUser" }, createTestContext(db));
+
+			// Create asset
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "AMD",
+				name: "AMD",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "AMD",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Price same as average buy price
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 10000,
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// Portfolio with no unrealized gains but has realized gains
+			const portfolio: InsertDbInvestmentPortfolio = {
+				userId: user.id,
+				assetId: asset.id,
+				quantity: 10000,
+				averageBuyPrice: 10000, // Same as current price
+				totalInvested: 1000,
+				realizedGains: 500, // From previous sells
+			};
+
+			await db.insert(investmentPortfoliosTable).values(portfolio);
+
+			const result = await call(getInvestmentSummary, { userId: user.id }, createTestContext(db));
+
+			expect(result.unrealizedGains).toBe(0);
+			expect(result.realizedGains).toBe(500);
+			expect(result.totalProfit).toBe(500);
+		});
+	});
+
+	describe("userStatsWithInvestments", () => {
+		it("should return user stats + investment summary", async () => {
+			const user = await call(createUser, { username: "statsInvestUser" }, createTestContext(db));
+
+			// Create asset and portfolio
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "UBER",
+				name: "Uber",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "UBER",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Create price cache
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 5000,
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// Create portfolio
+			const portfolio: InsertDbInvestmentPortfolio = {
+				userId: user.id,
+				assetId: asset.id,
+				quantity: 10000,
+				averageBuyPrice: 4000,
+				totalInvested: 400,
+				realizedGains: 50,
+			};
+
+			await db.insert(investmentPortfoliosTable).values(portfolio);
+
+			const result = await call(userStatsWithInvestments, { id: user.id }, createTestContext(db));
+
+			expect(result.stats).toBeDefined();
+			expect(result.stats.userId).toBe(user.id);
+			expect(result.levelProgress).toBeDefined();
+			expect(result.investments).toBeDefined();
+			expect(result.investments.totalInvested).toBe(400);
+			expect(result.investments.currentValue).toBe(500);
+			expect(result.totalWealth).toBeDefined();
+		});
+
+		it("should return totalWealth = coins + investment currentValue", async () => {
+			const user = await call(createUser, { username: "wealthUser" }, createTestContext(db));
+
+			// Get user stats to check initial coins
+			const stats = await call(userStatsWithInvestments, { id: user.id }, createTestContext(db));
+			const initialCoins = stats.stats.coinsCount;
+
+			// Create asset and portfolio
+			const assetData: InsertDbInvestmentAsset = {
+				symbol: "LYFT",
+				name: "Lyft",
+				assetType: "stock_us",
+				apiSource: "twelvedata",
+				apiSymbol: "LYFT",
+				isActive: true,
+				minInvestment: 100,
+			};
+			const [asset] = await db.insert(investmentAssetsTable).values(assetData).returning();
+
+			if (!asset) throw new Error("Failed to create asset");
+
+			// Create price cache
+			const priceData: InsertDbInvestmentPriceCache = {
+				assetId: asset.id,
+				price: 2000,
+				priceTimestamp: new Date(),
+			};
+			await db.insert(investmentPriceCacheTable).values(priceData);
+
+			// Create portfolio worth 1000
+			const portfolio: InsertDbInvestmentPortfolio = {
+				userId: user.id,
+				assetId: asset.id,
+				quantity: 50000, // 50 shares @ $20 = 1000
+				averageBuyPrice: 2000,
+				totalInvested: 1000,
+				realizedGains: 0,
+			};
+
+			await db.insert(investmentPortfoliosTable).values(portfolio);
+
+			const result = await call(userStatsWithInvestments, { id: user.id }, createTestContext(db));
+
+			expect(result.investments.currentValue).toBe(1000);
+			expect(result.totalWealth).toBe(initialCoins + 1000);
+		});
+
+		it("should handle user with no investments", async () => {
+			const user = await call(createUser, { username: "noInvestStatsUser" }, createTestContext(db));
+
+			const result = await call(userStatsWithInvestments, { id: user.id }, createTestContext(db));
+
+			expect(result.stats).toBeDefined();
+			expect(result.investments.totalInvested).toBe(0);
+			expect(result.investments.currentValue).toBe(0);
+			expect(result.investments.holdingsCount).toBe(0);
+			expect(result.totalWealth).toBe(result.stats.coinsCount);
+		});
+
+		it("should throw NOT_FOUND for non-existent user", async () => {
+			expect(async () => {
+				await call(userStatsWithInvestments, { id: 999999 }, createTestContext(db));
+			}).toThrow(
+				new ORPCError("NOT_FOUND", {
+					message: "User not found for the given identifiers / userStatsWithInvestments",
+				}),
+			);
+		});
+	});
+});

--- a/src/contract/router.ts
+++ b/src/contract/router.ts
@@ -52,6 +52,7 @@ import {
 	updateSuspiciousScore,
 	userDailyCooldown,
 	userStats,
+	userStatsWithInvestments,
 	userWorkCooldown,
 } from "./stats";
 // Review System (temporarily disabled - reviews are now part of violations table)
@@ -70,8 +71,10 @@ import { createUser, getUser, updateUser } from "./users";
 // Investment System
 import {
 	buyAsset,
+	getInvestmentSummary,
 	getPortfolio,
 	getTransactionHistory,
+	investmentLeaderboard,
 	listAvailableAssets,
 	sellAsset,
 	syncPrices,
@@ -135,6 +138,7 @@ export const router = {
 		//     },
 		stats: {
 			user: userStats,
+			userWithInvestments: userStatsWithInvestments, // GET /users/stats/userWithInvestments - user stats with investment summary
 			daily: {
 				cooldown: userDailyCooldown,
 				claim: claimDaily,
@@ -215,6 +219,8 @@ export const router = {
 			buy: buyAsset, // POST /users/investments/buy
 			sell: sellAsset, // POST /users/investments/sell
 			portfolio: getPortfolio, // GET /users/investments/portfolio
+			summary: getInvestmentSummary, // GET /users/investments/summary - aggregated investment stats
+			leaderboard: investmentLeaderboard, // GET /users/investments/leaderboard - top investors
 			assets: listAvailableAssets, // GET /users/investments/assets
 			transactions: getTransactionHistory, // GET /users/investments/transactions
 			sync: syncPrices, // POST /users/investments/sync - Manual price sync (admin only)

--- a/src/contract/stats/index.ts
+++ b/src/contract/stats/index.ts
@@ -1,9 +1,11 @@
-import { and, desc, eq, gte, lt } from "drizzle-orm";
+import { and, desc, eq, gte, lt, sql } from "drizzle-orm";
+import type { BunSQLDatabase } from "drizzle-orm/bun-sql/postgres";
 import { z } from "zod";
 import {
 	captchaLogsTable,
 	type InsertDbCaptchaLog,
 	type InsertDbUserStatsLog,
+	investmentPortfoliosTable,
 	userSchema,
 	userStatsLogSchema,
 	userStatsLogTable,
@@ -11,6 +13,8 @@ import {
 	userStatsTable,
 	usersTable,
 } from "../../db/schema.ts";
+import type * as schema from "../../db/schema.ts";
+import type { relations } from "../../db/relations.ts";
 import {
 	calculateLevel,
 	calculateRewards,
@@ -99,14 +103,151 @@ export const userStats = base
 	});
 
 /**
+ * Investment summary schema for stats endpoint
+ */
+const investmentSummarySchema = z.object({
+	totalInvested: z.number(),
+	currentValue: z.number(),
+	totalProfit: z.number(),
+	profitPercent: z.number(),
+	holdingsCount: z.number(),
+});
+
+/**
+ * User stats with investments retrieval contract
+ * Returns user stats combined with their investment portfolio summary
+ * Useful for /points command to show total wealth
+ */
+export const userStatsWithInvestments = base
+	.input(
+		userSchema
+			.pick({
+				id: true,
+				discordId: true,
+				guildedId: true,
+				username: true,
+				email: true,
+			})
+			.partial(),
+	)
+	.output(
+		z.object({
+			stats: userStatsSchema,
+			levelProgress: levelProgressSchema,
+			investments: investmentSummarySchema,
+			totalWealth: z.number(), // coins + currentValue of investments
+		}),
+	)
+	.handler(async ({ input, context, errors }) => {
+		// Find user with any of the provided identifiers
+		let user: { id: number; stats: typeof userStatsTable.$inferSelect | null } | null | undefined = null;
+		if (input.id !== undefined) {
+			user = await context.db.query.usersTable.findFirst({
+				where: { id: input.id },
+				with: { stats: true },
+				columns: { id: true },
+			});
+		} else if (input.discordId !== undefined && input.discordId !== null) {
+			user = await context.db.query.usersTable.findFirst({
+				where: { discordId: input.discordId as string },
+				with: { stats: true },
+				columns: { id: true },
+			});
+		} else if (input.guildedId !== undefined && input.guildedId !== null) {
+			user = await context.db.query.usersTable.findFirst({
+				where: { guildedId: input.guildedId as string },
+				with: { stats: true },
+				columns: { id: true },
+			});
+		}
+
+		if (!user)
+			throw errors.NOT_FOUND({
+				message: "User not found for the given identifiers / userStatsWithInvestments",
+			});
+		const stats = user?.stats;
+
+		if (!stats) {
+			throw errors.NOT_FOUND({
+				message: "User stats not found for the given user / userStatsWithInvestments",
+			});
+		}
+
+		const levelProgress = getLevelProgress(stats.xpCount);
+
+		// Get investment summary
+		const portfolios = await context.db
+			.select()
+			.from(investmentPortfoliosTable)
+			.where(eq(investmentPortfoliosTable.userId, user.id));
+
+		let totalInvested = 0;
+		let currentValue = 0;
+		let holdingsCount = 0;
+
+		for (const portfolio of portfolios) {
+			if (portfolio.quantity > 0) {
+				holdingsCount++;
+			}
+
+			// Get latest price for this asset
+			const priceData = await context.db.query.investmentPriceCacheTable.findFirst({
+				where: { assetId: portfolio.assetId },
+				orderBy: { priceTimestamp: "desc" },
+			});
+
+			const currentPrice = priceData?.price || portfolio.averageBuyPrice;
+			const portfolioValue = Math.floor((portfolio.quantity * currentPrice) / 100000);
+
+			totalInvested += portfolio.totalInvested;
+			currentValue += portfolioValue;
+		}
+
+		const totalProfit = currentValue - totalInvested;
+		const profitPercent = totalInvested > 0
+			? Math.round((totalProfit / totalInvested) * 10000) / 100
+			: 0;
+
+		const investments = {
+			totalInvested,
+			currentValue,
+			totalProfit,
+			profitPercent,
+			holdingsCount,
+		};
+
+		return {
+			stats,
+			levelProgress,
+			investments,
+			totalWealth: stats.coinsCount + currentValue,
+		};
+	});
+
+/**
+ * Standard metrics that can be queried from user_stats table
+ */
+const standardMetrics = ["coins", "xp", "level", "dailystreak", "maxdailystreak", "workcount"] as const;
+
+/**
+ * Investment metrics that require portfolio calculations
+ */
+const investmentMetrics = ["investmentvalue", "investmentprofit", "totalwealth"] as const;
+
+/**
+ * All available metrics for leaderboard
+ */
+const allMetrics = [...standardMetrics, ...investmentMetrics] as const;
+
+/**
  * Top users leaderboard contract
  * GET /users/leaderboard - Retrieves top users by specified metric
- * Supports various metrics and configurable limit
+ * Supports various metrics including investment-based ones and configurable limit
  */
 export const leaderboard = base
 	.input(
 		z.object({
-			metric: z.enum(["coins", "xp", "level", "dailystreak", "maxdailystreak", "workcount"]).default("coins"),
+			metric: z.enum(allMetrics).default("coins"),
 			limit: z.number().int().min(1).max(100).default(10),
 		}),
 	)
@@ -122,7 +263,15 @@ export const leaderboard = base
 	.handler(async ({ input, context }) => {
 		const { metric, limit } = input;
 
-		// Map metric to the actual column name
+		// Check if this is an investment-based metric
+		const isInvestmentMetric = (investmentMetrics as readonly string[]).includes(metric);
+
+		if (isInvestmentMetric) {
+			// Handle investment metrics - requires portfolio calculations
+			return await calculateInvestmentLeaderboard(context, metric as typeof investmentMetrics[number], limit);
+		}
+
+		// Standard metrics from user_stats table
 		const metricColumn = {
 			coins: userStatsTable.coinsCount,
 			xp: userStatsTable.xpCount,
@@ -130,7 +279,7 @@ export const leaderboard = base
 			dailystreak: userStatsTable.dailyStreak,
 			maxdailystreak: userStatsTable.maxDailyStreak,
 			workcount: userStatsTable.workCount,
-		}[metric];
+		}[metric as typeof standardMetrics[number]];
 
 		// Query the top users with their stats
 		const topUsers = await context.db
@@ -165,6 +314,132 @@ export const leaderboard = base
 			};
 		});
 	});
+
+/**
+ * Helper function to calculate investment-based leaderboards
+ */
+async function calculateInvestmentLeaderboard(
+	context: { db: BunSQLDatabase<typeof schema, typeof relations> },
+	metric: (typeof investmentMetrics)[number],
+	limit: number,
+): Promise<Array<{
+	user: { id: number; discordId: string | null; guildedId: string | null; username: string | null };
+	metricValue: number;
+	rank: number;
+}>> {
+	// Get all portfolios with positive holdings
+	const portfolios = await context.db
+		.select({
+			userId: investmentPortfoliosTable.userId,
+			assetId: investmentPortfoliosTable.assetId,
+			quantity: investmentPortfoliosTable.quantity,
+			totalInvested: investmentPortfoliosTable.totalInvested,
+			realizedGains: investmentPortfoliosTable.realizedGains,
+			averageBuyPrice: investmentPortfoliosTable.averageBuyPrice,
+		})
+		.from(investmentPortfoliosTable);
+
+	if (portfolios.length === 0) {
+		return [];
+	}
+
+	// Get latest prices for all assets
+	const assetIds = [...new Set(portfolios.map((p) => p.assetId))];
+	const priceMap = new Map<number, number>();
+
+	for (const assetId of assetIds) {
+		const priceData = await context.db.query.investmentPriceCacheTable.findFirst({
+			where: { assetId },
+			orderBy: { priceTimestamp: "desc" },
+		});
+		if (priceData) {
+			priceMap.set(assetId, priceData.price);
+		}
+	}
+
+	// Aggregate metrics by user
+	const userMetrics = new Map<number, { totalInvested: number; currentValue: number; realizedGains: number }>();
+
+	for (const portfolio of portfolios) {
+		const currentPrice = priceMap.get(portfolio.assetId) || portfolio.averageBuyPrice;
+		const currentValue = Math.floor((portfolio.quantity * currentPrice) / 100000);
+
+		const existing = userMetrics.get(portfolio.userId) || { totalInvested: 0, currentValue: 0, realizedGains: 0 };
+		userMetrics.set(portfolio.userId, {
+			totalInvested: existing.totalInvested + portfolio.totalInvested,
+			currentValue: existing.currentValue + currentValue,
+			realizedGains: existing.realizedGains + portfolio.realizedGains,
+		});
+	}
+
+	// Get user info and coins for totalwealth calculation
+	const userIds = [...userMetrics.keys()];
+	if (userIds.length === 0) {
+		return [];
+	}
+
+	const users = await context.db
+		.select({
+			id: usersTable.id,
+			discordId: usersTable.discordId,
+			guildedId: usersTable.guildedId,
+			username: usersTable.username,
+		})
+		.from(usersTable)
+		.where(sql`${usersTable.id} IN (${sql.join(userIds.map((id) => sql`${id}`), sql`, `)})`);
+
+	const userMap = new Map(users.map((u) => [u.id, u]));
+
+	// Get coins for totalwealth metric
+	let userCoinsMap = new Map<number, number>();
+	if (metric === "totalwealth") {
+		const userStatsRows = await context.db
+			.select({
+				userId: userStatsTable.userId,
+				coinsCount: userStatsTable.coinsCount,
+			})
+			.from(userStatsTable)
+			.where(sql`${userStatsTable.userId} IN (${sql.join(userIds.map((id) => sql`${id}`), sql`, `)})`);
+
+		userCoinsMap = new Map(userStatsRows.map((s) => [s.userId, s.coinsCount]));
+	}
+
+	// Build entries with metric values
+	const entries = [...userMetrics.entries()]
+		.map(([userId, metrics]) => {
+			const user = userMap.get(userId);
+			if (!user) return null;
+
+			let metricValue: number;
+			switch (metric) {
+				case "investmentvalue":
+					metricValue = metrics.currentValue;
+					break;
+				case "investmentprofit":
+					metricValue = metrics.currentValue - metrics.totalInvested + metrics.realizedGains;
+					break;
+				case "totalwealth": {
+					const coins = userCoinsMap.get(userId) || 0;
+					metricValue = coins + metrics.currentValue;
+					break;
+				}
+				default:
+					metricValue = 0;
+			}
+
+			return { user, metricValue };
+		})
+		.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+	// Sort by metric value descending and add ranks
+	return entries
+		.sort((a, b) => b.metricValue - a.metricValue)
+		.slice(0, limit)
+		.map((entry, index) => ({
+			...entry,
+			rank: index + 1,
+		}));
+}
 
 /**
  * Log captcha attempt with detailed reasoning

--- a/src/contract/stats/index.ts
+++ b/src/contract/stats/index.ts
@@ -184,6 +184,7 @@ export const userStatsWithInvestments = base
 		let totalInvested = 0;
 		let currentValue = 0;
 		let holdingsCount = 0;
+		let realizedGains = 0;
 
 		for (const portfolio of portfolios) {
 			if (portfolio.quantity > 0) {
@@ -201,9 +202,11 @@ export const userStatsWithInvestments = base
 
 			totalInvested += portfolio.totalInvested;
 			currentValue += portfolioValue;
+			realizedGains += portfolio.realizedGains;
 		}
 
-		const totalProfit = currentValue - totalInvested;
+		const unrealizedGains = currentValue - totalInvested;
+		const totalProfit = realizedGains + unrealizedGains;
 		const profitPercent = totalInvested > 0
 			? Math.round((totalProfit / totalInvested) * 10000) / 100
 			: 0;


### PR DESCRIPTION
- Add investmentLeaderboard endpoint with metrics: totalValue, totalProfit, profitPercent
- Add getInvestmentSummary endpoint for single user investment stats
- Add userStatsWithInvestments endpoint combining user stats with portfolio summary
- Extend main leaderboard with investment metrics: investmentvalue, investmentprofit, totalwealth
- Register all new endpoints in router