### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/evobug-com/api/security/code-scanning/1](https://github.com/evobug-com/api/security/code-scanning/1)

To resolve this issue, add a `permissions` key to the workflow file (.github/workflows/test.yml), setting it to the minimum needed for the jobs to complete. Since the given workflow only checks out code, installs dependencies, and runs tests locally (no push, no issue or PR manipulation), it only needs read access to repository contents.  
Best practice is to add the following at the top level (recommended), just below the workflow name and above `on`, so all jobs inherit these minimal permissions:

```yaml
permissions:
  contents: read
```

No imports, definitions, or changes elsewhere are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
